### PR TITLE
Remove the unnecessary 'import cv'

### DIFF
--- a/img_utils.py
+++ b/img_utils.py
@@ -4,7 +4,6 @@ import numpy as np
 from scipy.misc import imsave, imread, imresize
 from sklearn.feature_extraction.image import reconstruct_from_patches_2d, extract_patches_2d
 from scipy.ndimage.filters import gaussian_filter
-import cv
 
 from keras import backend as K
 


### PR DESCRIPTION
img_utils.py does an unnecessary import cv

The issue is that newer opencv installs might not have a "cv" module, just a "cv2" one, so this stops the program from running for no reason